### PR TITLE
Add Upstart job.

### DIFF
--- a/hulk.cabal
+++ b/hulk.cabal
@@ -23,6 +23,7 @@ extra-source-files:
   example/hulk.conf
   example/users/hulk2
   example/users/hulk
+  scripts/upstart/hulk.conf
 
 library
   exposed-modules:   Hulk.Server

--- a/scripts/upstart/hulk.conf
+++ b/scripts/upstart/hulk.conf
@@ -1,0 +1,9 @@
+description "hulk - Haskell IRC server"
+
+start on filesystem
+stop on runlevel [016]
+
+respawn
+
+# Change according to installed location
+exec hulk -c /path/to/hulk.conf


### PR DESCRIPTION
Still needs to be modified according to the installed location, as well as be installed to the Upstart configuration directory itself, but useful nonetheless.
